### PR TITLE
Adds bar details painting

### DIFF
--- a/example/lib/helpers.dart
+++ b/example/lib/helpers.dart
@@ -115,7 +115,7 @@ List<ZoneSegment> generateZoneSegments({
   return segments;
 }
 
-const List<Color> colors = [
+const List<Color> primaryZoneColors = [
   Color(0xFF5A5A5A), // Zone 1
   Color(0xFF00B0F0), // Zone 2
   Color(0xFF00B050), // Zone 3
@@ -150,7 +150,7 @@ List<double> zoneMaxes = [54, 75, 90, 105, 120, 150, 180];
 
 Color getGradientZoneColorFromPercentage(double percentage) {
   if (percentage > 150) {
-    return colors.last;
+    return primaryZoneColors.last;
   }
 
   int zoneIndex = 0;
@@ -169,9 +169,10 @@ Color getGradientZoneColorFromPercentage(double percentage) {
   double exponent = 1 + (zoneSize / 20);
   fraction = pow(fraction, exponent).toDouble();
 
-  Color startColor = colors[zoneIndex];
-  Color endColor =
-      zoneIndex < colors.length - 1 ? colors[zoneIndex + 1] : colors[zoneIndex];
+  Color startColor = primaryZoneColors[zoneIndex];
+  Color endColor = zoneIndex < primaryZoneColors.length - 1
+      ? primaryZoneColors[zoneIndex + 1]
+      : primaryZoneColors[zoneIndex];
   return Color.lerp(startColor, endColor, fraction)!;
 }
 

--- a/lib/flutter_custom_charts.dart
+++ b/lib/flutter_custom_charts.dart
@@ -31,3 +31,5 @@ part 'src/models/constrained_area.dart';
 part 'src/models/range.dart';
 part 'src/util/helpers.dart';
 part 'src/util//simplify.dart';
+part 'src/models/bar_details.dart';
+part 'src/models/axis_details.dart';

--- a/lib/src/charts/xy_chart.dart
+++ b/lib/src/charts/xy_chart.dart
@@ -36,11 +36,13 @@ class XYChart extends StatelessWidget {
           }
         },
         child: ClipRect(
-          child: CustomPaint(
-            painter: ChartCanvas(
-              primaryAxisController: primaryAxisController,
-              padding: padding,
-              fill: fill,
+          child: RepaintBoundary(
+            child: CustomPaint(
+              painter: ChartCanvas(
+                primaryAxisController: primaryAxisController,
+                padding: padding,
+                fill: fill,
+              ),
             ),
           ),
         ),

--- a/lib/src/controllers/axis_controller.dart
+++ b/lib/src/controllers/axis_controller.dart
@@ -1,45 +1,19 @@
 part of flutter_custom_charts;
 
-class AxisDetails {
-  const AxisDetails({
-    required this.stepLabelFormatter,
-    this.steps = 6,
-    this.crossAlignmentPixelSize = 32,
-    this.name,
-    this.nameLabelStyle = const TextStyle(fontSize: 12, color: Colors.white),
-    this.stepLabelStyle = const TextStyle(fontSize: 12, color: Colors.white),
-    this.gridStyle = const AxisGridStyle(
-      color: Colors.grey,
-      strokeWidth: 1,
-    ),
+class _ChartAxisArea {
+  _ChartAxisArea({
+    required this.axisIndex,
+    required this.position,
+    required this.area,
   });
 
-  final String? name;
-  final TextStyle nameLabelStyle;
-  final TextStyle stepLabelStyle;
-  final String Function(double value) stepLabelFormatter;
-  final double crossAlignmentPixelSize;
-  final int steps;
-  final AxisGridStyle? gridStyle;
-}
+  final int axisIndex;
+  final AxisPosition position;
+  ConstrainedArea area;
 
-class AxisGridStyle {
-  const AxisGridStyle({
-    required this.color,
-    required this.strokeWidth,
-  });
-
-  final Color color;
-  final double strokeWidth;
-}
-
-class BarDetailsSpacing {
-  const BarDetailsSpacing({
-    this.spaceAbove,
-    this.spaceBelow,
-  });
-  final double? spaceAbove;
-  final double? spaceBelow;
+  @override
+  String toString() =>
+      '_ChartAxisArea(axisIndex: $axisIndex, position: $position, area: $area)';
 }
 
 abstract class _AxisController extends ChangeNotifier {
@@ -191,22 +165,6 @@ abstract class _AxisController extends ChangeNotifier {
       );
     }
   }
-}
-
-class _ChartAxisArea {
-  _ChartAxisArea({
-    required this.axisIndex,
-    required this.position,
-    required this.area,
-  });
-
-  final int axisIndex;
-  final AxisPosition position;
-  ConstrainedArea area;
-
-  @override
-  String toString() =>
-      '_ChartAxisArea(axisIndex: $axisIndex, position: $position, area: $area)';
 }
 
 abstract class PrimaryAxisController extends _AxisController

--- a/lib/src/controllers/axis_controller.dart
+++ b/lib/src/controllers/axis_controller.dart
@@ -33,6 +33,15 @@ class AxisGridStyle {
   final double strokeWidth;
 }
 
+class BarDetailsSpacing {
+  const BarDetailsSpacing({
+    this.spaceAbove,
+    this.spaceBelow,
+  });
+  final double? spaceAbove;
+  final double? spaceBelow;
+}
+
 abstract class _AxisController extends ChangeNotifier {
   _AxisController({
     required this.position,
@@ -207,15 +216,13 @@ abstract class PrimaryAxisController extends _AxisController
     required super.position,
     required this.isScrollable,
     this.scrollableRange,
-    this.detailsAboveSize,
-    this.detailsBelowSize,
+    this.barDetailsSpacing,
     super.explicitRange,
     super.onExplicitRangeChange,
   });
 
   final bool isScrollable;
-  final double? detailsAboveSize;
-  final double? detailsBelowSize;
+  final BarDetailsSpacing? barDetailsSpacing;
   final Range? scrollableRange;
   ChartAnimation? _zoomAnimation;
   final List<_ChartAxisArea> _axisAreas = [];

--- a/lib/src/controllers/category_axis_controller.dart
+++ b/lib/src/controllers/category_axis_controller.dart
@@ -8,8 +8,7 @@ class PrimaryCategoryAxisController<T extends BarDataset,
     super.isScrollable = true,
     super.scrollableRange,
     super.explicitRange,
-    super.detailsAboveSize,
-    super.detailsBelowSize,
+    super.barDetailsSpacing,
   }) {
     for (final secondary in secondaryAxisControllers) {
       verifyAxisPositions(position, secondary.position);

--- a/lib/src/entities/bar.dart
+++ b/lib/src/entities/bar.dart
@@ -98,7 +98,7 @@ class Bar extends PlottableXYEntity with ConstrainedPainter {
 
       final center = constraints.center();
       final x = center.dx - (tp.width / 2);
-      final y = constraints.yMin - (tp.height / 2);
+      final y = center.dy - (tp.height / 2);
       tp.paint(canvas, Offset(x, y));
     }
 
@@ -123,9 +123,33 @@ class Bar extends PlottableXYEntity with ConstrainedPainter {
 
       final center = constraints.center();
       final x = center.dx - (tp.width / 2);
-      final y = constraints.yMin - (tp.height / 2);
+      final y = center.dy - (tp.height / 2);
       tp.paint(canvas, Offset(x, y));
     }
+  }
+
+  void paintDetailsAbove(
+    Canvas canvas, {
+    required ConstrainedArea constraints,
+    required BarDetails details,
+  }) {
+    _paintDetails(
+      canvas,
+      constraints: constraints,
+      details: details,
+    );
+  }
+
+  void paintDetailsBelow(
+    Canvas canvas, {
+    required ConstrainedArea constraints,
+    required BarDetails details,
+  }) {
+    _paintDetails(
+      canvas,
+      constraints: constraints,
+      details: details,
+    );
   }
 
   @override
@@ -181,7 +205,7 @@ class Bar extends PlottableXYEntity with ConstrainedPainter {
     }
 
     if (detailsAboveConstraints != null && detailsAbove != null) {
-      _paintDetails(
+      paintDetailsAbove(
         canvas,
         constraints: detailsAboveConstraints,
         details: detailsAbove!,
@@ -189,7 +213,7 @@ class Bar extends PlottableXYEntity with ConstrainedPainter {
     }
 
     if (detailsBelowConstraints != null && detailsBelow != null) {
-      _paintDetails(
+      paintDetailsBelow(
         canvas,
         constraints: detailsBelowConstraints,
         details: detailsBelow!,

--- a/lib/src/entities/bar.dart
+++ b/lib/src/entities/bar.dart
@@ -2,39 +2,6 @@ part of flutter_custom_charts;
 
 // TODO - change secondaryAxisMax and secondaryAxisMin to a Range instance
 
-class ChartIcon {
-  ChartIcon({
-    required this.icon,
-    required this.size,
-    required this.color,
-  });
-
-  final IconData icon;
-  final double size;
-  final Color color;
-}
-
-// TODO - use this class for all labels/text throughout the library
-class ChartText {
-  ChartText({
-    required this.text,
-    required this.style,
-  });
-
-  final String text;
-  final TextStyle style;
-}
-
-class BarDetails {
-  BarDetails({
-    this.icon,
-    this.text,
-  });
-
-  final ChartText? text;
-  final ChartIcon? icon;
-}
-
 class Bar extends PlottableXYEntity with ConstrainedPainter {
   Bar({
     required this.primaryAxisMin,

--- a/lib/src/models/axis_details.dart
+++ b/lib/src/models/axis_details.dart
@@ -1,0 +1,34 @@
+part of flutter_custom_charts;
+
+class AxisDetails {
+  const AxisDetails({
+    required this.stepLabelFormatter,
+    this.steps = 6,
+    this.crossAlignmentPixelSize = 32,
+    this.name,
+    this.nameLabelStyle = const TextStyle(fontSize: 12, color: Colors.white),
+    this.stepLabelStyle = const TextStyle(fontSize: 12, color: Colors.white),
+    this.gridStyle = const AxisGridStyle(
+      color: Colors.grey,
+      strokeWidth: 1,
+    ),
+  });
+
+  final String? name;
+  final TextStyle nameLabelStyle;
+  final TextStyle stepLabelStyle;
+  final String Function(double value) stepLabelFormatter;
+  final double crossAlignmentPixelSize;
+  final int steps;
+  final AxisGridStyle? gridStyle;
+}
+
+class AxisGridStyle {
+  const AxisGridStyle({
+    required this.color,
+    required this.strokeWidth,
+  });
+
+  final Color color;
+  final double strokeWidth;
+}

--- a/lib/src/models/bar_details.dart
+++ b/lib/src/models/bar_details.dart
@@ -1,0 +1,43 @@
+part of flutter_custom_charts;
+
+class ChartIcon {
+  ChartIcon({
+    required this.icon,
+    required this.size,
+    required this.color,
+  });
+
+  final IconData icon;
+  final double size;
+  final Color color;
+}
+
+// TODO - use this class for all labels/text throughout the library
+class ChartText {
+  ChartText({
+    required this.text,
+    required this.style,
+  });
+
+  final String text;
+  final TextStyle style;
+}
+
+class BarDetails {
+  BarDetails({
+    this.icon,
+    this.text,
+  });
+
+  final ChartText? text;
+  final ChartIcon? icon;
+}
+
+class BarDetailsSpacing {
+  const BarDetailsSpacing({
+    this.spaceAbove,
+    this.spaceBelow,
+  });
+  final double? spaceAbove;
+  final double? spaceBelow;
+}

--- a/lib/src/util/helpers.dart
+++ b/lib/src/util/helpers.dart
@@ -274,6 +274,94 @@ ConstrainedArea determineAxisDetailsConstraints({
   }
 }
 
+ConstrainedArea determineBarDetailsSpacingAbove({
+  required ConstrainedArea barConstraints,
+  required AxisPosition position,
+  required double spacing,
+}) {
+  switch (position) {
+    case AxisPosition.left:
+      return barConstraints.copyWith(
+        xMin: barConstraints.xMax,
+        xMax: barConstraints.xMax + spacing,
+      );
+    case AxisPosition.right:
+      return barConstraints.copyWith(
+        xMax: barConstraints.xMin,
+        xMin: barConstraints.xMin - spacing,
+      );
+    case AxisPosition.top:
+      return barConstraints.copyWith(
+        yMin: barConstraints.yMax,
+        yMax: barConstraints.yMax + spacing,
+      );
+    case AxisPosition.bottom:
+      return barConstraints.copyWith(
+        yMin: barConstraints.yMin - spacing,
+        yMax: barConstraints.yMin,
+      );
+  }
+}
+
+ConstrainedArea determineBarDetailsSpacingBelow({
+  required ConstrainedArea barConstraints,
+  required AxisPosition position,
+  required double spacing,
+}) {
+  switch (position) {
+    case AxisPosition.left:
+      return barConstraints.copyWith(
+        xMax: barConstraints.xMin,
+        xMin: barConstraints.xMin - spacing,
+      );
+    case AxisPosition.right:
+      return barConstraints.copyWith(
+        xMin: barConstraints.xMax,
+        xMax: barConstraints.xMax + spacing,
+      );
+    case AxisPosition.top:
+      return barConstraints.copyWith(
+        yMin: barConstraints.yMin - spacing,
+        yMax: barConstraints.yMin,
+      );
+    case AxisPosition.bottom:
+      return barConstraints.copyWith(
+        yMin: barConstraints.yMax,
+        yMax: barConstraints.yMax + spacing,
+      );
+  }
+}
+
+ConstrainedArea determineClippedArea({
+  required ConstrainedArea constraints,
+  required AxisPosition position,
+  required double? barSpacingAbove,
+  required double? barSpacingBelow,
+}) {
+  switch (position) {
+    case AxisPosition.left:
+      return constraints.copyWith(
+        xMin: constraints.xMin - (barSpacingBelow ?? 0),
+        xMax: constraints.xMax + (barSpacingAbove ?? 0),
+      );
+    case AxisPosition.right:
+      return constraints.copyWith(
+        xMin: constraints.xMin - (barSpacingAbove ?? 0),
+        xMax: constraints.xMax + (barSpacingBelow ?? 0),
+      );
+    case AxisPosition.top:
+      return constraints.copyWith(
+        yMin: constraints.yMin - (barSpacingBelow ?? 0),
+        yMax: constraints.yMax + (barSpacingAbove ?? 0),
+      );
+    case AxisPosition.bottom:
+      return constraints.copyWith(
+        yMin: constraints.yMin - (barSpacingAbove ?? 0),
+        yMax: constraints.yMax + (barSpacingBelow ?? 0),
+      );
+  }
+}
+
 bool isSecondaryAxisInverted(AxisPosition primary) {
   switch (primary) {
     case AxisPosition.left:


### PR DESCRIPTION
- `Bar` class now exposes `paintDetailsAbove` and `paintDetailsBelow` methods to be overriden.
- `Bar` class now has optional constructor params `detailsAbove` and `detailsBelow` which accept a `BarDetails` class.
- `PrimaryAxisController` now has an optional `BarDetailsSpacing` constructor param.
- Areas for painting details above and below the data painting region are now allocated. (this addresses the issues that #9 outlines).
- Adds an example of how to do this.
- Fixes an issue where the chart was being repainted on window mouse entry(web)
- Extracts some models into their own files

Closes #9 